### PR TITLE
Replace List with Set

### DIFF
--- a/docs/data-sources/certificate.md
+++ b/docs/data-sources/certificate.md
@@ -29,7 +29,7 @@ data "nginxproxymanager_certificate" "certificate" {
 ### Read-Only
 
 - `created_on` (String) The date and time the certificate was created.
-- `domain_names` (List of String) The domain names associated with the certificate.
+- `domain_names` (Set of String) The domain names associated with the certificate.
 - `expires_on` (String) The date and time the certificate expires.
 - `meta` (Map of String, Sensitive) The meta data associated with the certificate.
 - `modified_on` (String) The date and time the certificate was last modified.

--- a/docs/data-sources/certificates.md
+++ b/docs/data-sources/certificates.md
@@ -30,7 +30,7 @@ data "nginxproxymanager_certificates" "certificates" {}
 Read-Only:
 
 - `created_on` (String) The date and time the certificate was created.
-- `domain_names` (List of String) The domain names associated with the certificate.
+- `domain_names` (Set of String) The domain names associated with the certificate.
 - `expires_on` (String) The date and time the certificate expires.
 - `id` (Number) The Id of the certificate.
 - `meta` (Map of String, Sensitive) The meta data associated with the certificate.

--- a/docs/data-sources/dead_host.md
+++ b/docs/data-sources/dead_host.md
@@ -31,7 +31,7 @@ data "nginxproxymanager_dead_host" "host" {
 - `advanced_config` (String) The advanced configuration used by the dead host.
 - `certificate_id` (Number) The Id of the certificate used by the dead host.
 - `created_on` (String) The date and time the dead host was created.
-- `domain_names` (List of String) The domain names associated with the dead host.
+- `domain_names` (Set of String) The domain names associated with the dead host.
 - `enabled` (Boolean) Whether the dead host is enabled.
 - `hsts_enabled` (Boolean) Whether HSTS is enabled for the dead host.
 - `hsts_subdomains` (Boolean) Whether HSTS is enabled for subdomains of the dead host.

--- a/docs/data-sources/dead_hosts.md
+++ b/docs/data-sources/dead_hosts.md
@@ -32,7 +32,7 @@ Read-Only:
 - `advanced_config` (String) The advanced configuration used by the dead host.
 - `certificate_id` (Number) The Id of the certificate used by the dead host.
 - `created_on` (String) The date and time the dead host was created.
-- `domain_names` (List of String) The domain names associated with the dead host.
+- `domain_names` (Set of String) The domain names associated with the dead host.
 - `enabled` (Boolean) Whether the dead host is enabled.
 - `hsts_enabled` (Boolean) Whether HSTS is enabled for the dead host.
 - `hsts_subdomains` (Boolean) Whether HSTS is enabled for subdomains of the dead host.

--- a/docs/data-sources/proxy_host.md
+++ b/docs/data-sources/proxy_host.md
@@ -35,7 +35,7 @@ data "nginxproxymanager_proxy_host" "host" {
 - `caching_enabled` (Boolean) Whether caching is enabled for the proxy host.
 - `certificate_id` (Number) The Id of the certificate used by the proxy host.
 - `created_on` (String) The date and time the proxy host was created.
-- `domain_names` (List of String) The domain names associated with the proxy host.
+- `domain_names` (Set of String) The domain names associated with the proxy host.
 - `enabled` (Boolean) Whether the proxy host is enabled.
 - `forward_host` (String) The host used to forward requests to the proxy host.
 - `forward_port` (Number) The port used to forward requests to the proxy host.

--- a/docs/data-sources/proxy_hosts.md
+++ b/docs/data-sources/proxy_hosts.md
@@ -36,7 +36,7 @@ Read-Only:
 - `caching_enabled` (Boolean) Whether caching is enabled for the proxy host.
 - `certificate_id` (Number) The Id of the certificate used by the proxy host.
 - `created_on` (String) The date and time the proxy host was created.
-- `domain_names` (List of String) The domain names associated with the proxy host.
+- `domain_names` (Set of String) The domain names associated with the proxy host.
 - `enabled` (Boolean) Whether the proxy host is enabled.
 - `forward_host` (String) The host used to forward requests to the proxy host.
 - `forward_port` (Number) The port used to forward requests to the proxy host.

--- a/docs/data-sources/redirection_host.md
+++ b/docs/data-sources/redirection_host.md
@@ -30,7 +30,7 @@ data "nginxproxymanager_redirection_hosts" "hosts" {}
 - `block_exploits` (Boolean) Whether exploits are blocked for the redirection host.
 - `certificate_id` (Number) The Id of the certificate used by the redirection host.
 - `created_on` (String) The date and time the redirection host was created.
-- `domain_names` (List of String) The domain names associated with the redirection host.
+- `domain_names` (Set of String) The domain names associated with the redirection host.
 - `enabled` (Boolean) Whether the redirection host is enabled.
 - `forward_domain_name` (String) The domain name used to forward requests to the redirection host.
 - `forward_http_code` (Number) The HTTP code used to forward requests to the redirection host.

--- a/docs/data-sources/redirection_hosts.md
+++ b/docs/data-sources/redirection_hosts.md
@@ -35,7 +35,7 @@ Read-Only:
 - `block_exploits` (Boolean) Whether exploits are blocked for the redirection host.
 - `certificate_id` (Number) The Id of the certificate used by the redirection host.
 - `created_on` (String) The date and time the redirection host was created.
-- `domain_names` (List of String) The domain names associated with the redirection host.
+- `domain_names` (Set of String) The domain names associated with the redirection host.
 - `enabled` (Boolean) Whether the redirection host is enabled.
 - `forward_domain_name` (String) The domain name used to forward requests to the redirection host.
 - `forward_http_code` (Number) The HTTP code used to forward requests to the redirection host.

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -36,7 +36,7 @@ data "nginxproxymanager_user" "user" {
 - `name` (String) The name of the user.
 - `nickname` (String) The nickname of the user.
 - `permissions` (Attributes) The permissions of the user. (see [below for nested schema](#nestedatt--permissions))
-- `roles` (List of String) The roles of the user.
+- `roles` (Set of String) The roles of the user.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/docs/data-sources/user_me.md
+++ b/docs/data-sources/user_me.md
@@ -31,7 +31,7 @@ data "nginxproxymanager_user_me" "user_me" {}
 - `name` (String) The name of the user.
 - `nickname` (String) The nickname of the user.
 - `permissions` (Attributes) The permissions of the user. (see [below for nested schema](#nestedatt--permissions))
-- `roles` (List of String) The roles of the user.
+- `roles` (Set of String) The roles of the user.
 
 <a id="nestedatt--permissions"></a>
 ### Nested Schema for `permissions`

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -38,7 +38,7 @@ Read-Only:
 - `name` (String) The name of the user.
 - `nickname` (String) The nickname of the user.
 - `permissions` (Attributes) The permissions of the user. (see [below for nested schema](#nestedatt--users--permissions))
-- `roles` (List of String) The roles of the user.
+- `roles` (Set of String) The roles of the user.
 
 <a id="nestedatt--users--permissions"></a>
 ### Nested Schema for `users.permissions`

--- a/docs/resources/certificate_custom.md
+++ b/docs/resources/certificate_custom.md
@@ -34,7 +34,7 @@ resource "nginxproxymanager_certificate_custom" "certificate" {
 ### Read-Only
 
 - `created_on` (String) The date and time the certificate was created.
-- `domain_names` (List of String) The domain names associated with the certificate.
+- `domain_names` (Set of String) The domain names associated with the certificate.
 - `expires_on` (String) The date and time the certificate expires.
 - `id` (Number) The ID of the certificate.
 - `modified_on` (String) The date and time the certificate was last modified.

--- a/docs/resources/certificate_letsencrypt.md
+++ b/docs/resources/certificate_letsencrypt.md
@@ -31,7 +31,7 @@ resource "nginxproxymanager_certificate_letsencrypt" "certificate" {
 
 ### Required
 
-- `domain_names` (List of String) The domain names associated with the certificate.
+- `domain_names` (Set of String) The domain names associated with the certificate.
 - `letsencrypt_agree` (Boolean) Whether you agree to the [Let's Encrypt Terms of Service](https://letsencrypt.org/repository/).
 - `letsencrypt_email` (String) The email address to use for the Let's Encrypt certificate.
 

--- a/docs/resources/dead_host.md
+++ b/docs/resources/dead_host.md
@@ -30,7 +30,7 @@ resource "nginxproxymanager_dead_host" "host" {
 
 ### Required
 
-- `domain_names` (List of String) The domain names associated with the dead host.
+- `domain_names` (Set of String) The domain names associated with the dead host.
 
 ### Optional
 

--- a/docs/resources/proxy_host.md
+++ b/docs/resources/proxy_host.md
@@ -55,7 +55,7 @@ resource "nginxproxymanager_proxy_host" "host" {
 
 ### Required
 
-- `domain_names` (List of String) The domain names associated with the proxy host.
+- `domain_names` (Set of String) The domain names associated with the proxy host.
 - `forward_host` (String) The host used to forward requests to the proxy host.
 - `forward_port` (Number) The port used to forward requests to the proxy host.
 - `forward_scheme` (String) The scheme used to forward requests to the proxy host. Can be either `http` or `https`.

--- a/docs/resources/redirection_host.md
+++ b/docs/resources/redirection_host.md
@@ -37,7 +37,7 @@ resource "nginxproxymanager_redirection_host" "host" {
 
 ### Required
 
-- `domain_names` (List of String) The domain names associated with the redirection host.
+- `domain_names` (Set of String) The domain names associated with the redirection host.
 - `forward_domain_name` (String) The domain name used to forward requests to the redirection host.
 
 ### Optional

--- a/internal/provider/certificate_custom_resource.go
+++ b/internal/provider/certificate_custom_resource.go
@@ -87,7 +87,7 @@ func (r *CertificateCustomResource) Schema(ctx context.Context, req resource.Sch
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the certificate.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/certificate_data_source.go
+++ b/internal/provider/certificate_data_source.go
@@ -57,7 +57,7 @@ func (d *CertificateDataSource) Schema(ctx context.Context, req datasource.Schem
 				MarkdownDescription: "The nice name of the certificate.",
 				Computed:            true,
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the certificate.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/certificate_letsencrypt_resource.go
+++ b/internal/provider/certificate_letsencrypt_resource.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -72,12 +72,12 @@ func (r *CertificateLetsencryptResource) Schema(ctx context.Context, req resourc
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the certificate.",
 				Required:            true,
 				ElementType:         types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.RequiresReplace(),
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
 				},
 			},
 			"letsencrypt_email": schema.StringAttribute{

--- a/internal/provider/certificates_data_source.go
+++ b/internal/provider/certificates_data_source.go
@@ -62,7 +62,7 @@ func (d *CertificatesDataSource) Schema(ctx context.Context, req datasource.Sche
 							MarkdownDescription: "The nice name of the certificate.",
 							Computed:            true,
 						},
-						"domain_names": schema.ListAttribute{
+						"domain_names": schema.SetAttribute{
 							MarkdownDescription: "The domain names associated with the certificate.",
 							Computed:            true,
 							ElementType:         types.StringType,

--- a/internal/provider/dead_host_data_source.go
+++ b/internal/provider/dead_host_data_source.go
@@ -49,7 +49,7 @@ func (d *DeadHostDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				MarkdownDescription: "The Id of the user that owns the dead host.",
 				Computed:            true,
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the dead host.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/dead_host_resource.go
+++ b/internal/provider/dead_host_resource.go
@@ -66,7 +66,7 @@ func (r *DeadHostResource) Schema(ctx context.Context, req resource.SchemaReques
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the dead host.",
 				Required:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/dead_hosts_data_source.go
+++ b/internal/provider/dead_hosts_data_source.go
@@ -54,7 +54,7 @@ func (d *DeadHostsDataSource) Schema(ctx context.Context, req datasource.SchemaR
 							MarkdownDescription: "The Id of the user that owns the dead host.",
 							Computed:            true,
 						},
-						"domain_names": schema.ListAttribute{
+						"domain_names": schema.SetAttribute{
 							MarkdownDescription: "The domain names associated with the dead host.",
 							Computed:            true,
 							ElementType:         types.StringType,

--- a/internal/provider/models/certificate.go
+++ b/internal/provider/models/certificate.go
@@ -20,7 +20,7 @@ type Certificate struct {
 
 	Provider    types.String `tfsdk:"provider_name"`
 	NiceName    types.String `tfsdk:"nice_name"`
-	DomainNames types.List   `tfsdk:"domain_names"`
+	DomainNames types.Set    `tfsdk:"domain_names"`
 	ExpiresOn   types.String `tfsdk:"expires_on"`
 }
 
@@ -33,7 +33,7 @@ func (_ Certificate) GetType() attr.Type {
 		"meta":          types.MapType{ElemType: types.StringType},
 		"provider_name": types.StringType,
 		"nice_name":     types.StringType,
-		"domain_names":  types.ListType{ElemType: types.StringType},
+		"domain_names":  types.SetType{ElemType: types.StringType},
 		"expires_on":    types.StringType,
 	})
 }
@@ -50,7 +50,7 @@ func (m *Certificate) Write(ctx context.Context, certificate *nginxproxymanager.
 	m.NiceName = types.StringValue(certificate.GetNiceName())
 	m.ExpiresOn = types.StringValue(certificate.GetExpiresOn())
 
-	m.DomainNames, tmpDiags = ListDomainNamesFrom(ctx, certificate.GetDomainNames())
+	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, certificate.GetDomainNames())
 	diags.Append(tmpDiags...)
 
 	meta, err := certificate.GetMeta().ToMap()

--- a/internal/provider/models/certificate_custom.go
+++ b/internal/provider/models/certificate_custom.go
@@ -20,7 +20,7 @@ type CertificateCustom struct {
 	Name           types.String `tfsdk:"name"`
 	Certificate    types.String `tfsdk:"certificate"`
 	CertificateKey types.String `tfsdk:"certificate_key"`
-	DomainNames    types.List   `tfsdk:"domain_names"`
+	DomainNames    types.Set    `tfsdk:"domain_names"`
 	ExpiresOn      types.String `tfsdk:"expires_on"`
 }
 
@@ -33,7 +33,7 @@ func (_ CertificateCustom) GetType() attr.Type {
 		"name":            types.StringType,
 		"certificate":     types.StringType,
 		"certificate_key": types.StringType,
-		"domain_names":    types.ListType{ElemType: types.StringType},
+		"domain_names":    types.SetType{ElemType: types.StringType},
 		"expires_on":      types.StringType,
 	})
 }
@@ -60,7 +60,7 @@ func (m *CertificateCustom) Write(ctx context.Context, certificate *nginxproxyma
 	}
 	m.ExpiresOn = types.StringValue(certificate.GetExpiresOn())
 
-	m.DomainNames, tmpDiags = ListDomainNamesFrom(ctx, certificate.GetDomainNames())
+	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, certificate.GetDomainNames())
 	diags.Append(tmpDiags...)
 }
 

--- a/internal/provider/models/certificate_letsencrypt.go
+++ b/internal/provider/models/certificate_letsencrypt.go
@@ -18,7 +18,7 @@ type CertificateLetsencrypt struct {
 	ExpiresOn   types.String `tfsdk:"expires_on"`
 	OwnerUserId types.Int64  `tfsdk:"owner_user_id"`
 
-	DomainNames            types.List   `tfsdk:"domain_names"`
+	DomainNames            types.Set    `tfsdk:"domain_names"`
 	LetsencryptEmail       types.String `tfsdk:"letsencrypt_email"`
 	LetsencryptAgree       types.Bool   `tfsdk:"letsencrypt_agree"`
 	DnsChallenge           types.Bool   `tfsdk:"dns_challenge"`
@@ -34,7 +34,7 @@ func (_ CertificateLetsencrypt) GetType() attr.Type {
 		"modified_on":              types.StringType,
 		"expires_on":               types.StringType,
 		"owner_user_id":            types.Int64Type,
-		"domain_names":             types.ListType{ElemType: types.StringType},
+		"domain_names":             types.SetType{ElemType: types.StringType},
 		"letsencrypt_email":        types.StringType,
 		"letsencrypt_agree":        types.BoolType,
 		"dns_challenge":            types.BoolType,
@@ -85,7 +85,7 @@ func (m *CertificateLetsencrypt) Write(ctx context.Context, certificate *nginxpr
 		m.PropagationSeconds = types.Int64Null()
 	}
 
-	m.DomainNames, tmpDiags = ListDomainNamesFrom(ctx, certificate.GetDomainNames())
+	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, certificate.GetDomainNames())
 	diags.Append(tmpDiags...)
 }
 

--- a/internal/provider/models/dead_host.go
+++ b/internal/provider/models/dead_host.go
@@ -18,7 +18,7 @@ type DeadHost struct {
 	OwnerUserId types.Int64  `tfsdk:"owner_user_id"`
 	Meta        types.Map    `tfsdk:"meta"`
 
-	DomainNames    types.List   `tfsdk:"domain_names"`
+	DomainNames    types.Set    `tfsdk:"domain_names"`
 	CertificateId  types.Int64  `tfsdk:"certificate_id"`
 	SslForced      types.Bool   `tfsdk:"ssl_forced"`
 	HstsEnabled    types.Bool   `tfsdk:"hsts_enabled"`
@@ -35,7 +35,7 @@ func (_ DeadHost) GetType() attr.Type {
 		"modified_on":     types.StringType,
 		"owner_user_id":   types.Int64Type,
 		"meta":            types.MapType{ElemType: types.StringType},
-		"domain_names":    types.ListType{ElemType: types.StringType},
+		"domain_names":    types.SetType{ElemType: types.StringType},
 		"certificate_id":  types.Int64Type,
 		"ssl_forced":      types.BoolType,
 		"hsts_enabled":    types.BoolType,
@@ -69,7 +69,7 @@ func (m *DeadHost) Write(ctx context.Context, deadHost *nginxproxymanager.GetDea
 	m.Meta, tmpDiags = MapMetaFrom(ctx, deadHost.GetMeta())
 	diags.Append(tmpDiags...)
 
-	m.DomainNames, tmpDiags = ListDomainNamesFrom(ctx, deadHost.GetDomainNames())
+	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, deadHost.GetDomainNames())
 	diags.Append(tmpDiags...)
 }
 

--- a/internal/provider/models/domain_names.go
+++ b/internal/provider/models/domain_names.go
@@ -10,13 +10,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-func ListDomainNamesFrom(ctx context.Context, domainNames []string) (basetypes.ListValue, diag.Diagnostics) {
-	return types.ListValueFrom(ctx, types.StringType, domainNames)
+func SetDomainNamesFrom(ctx context.Context, domainNames []string) (basetypes.SetValue, diag.Diagnostics) {
+	return types.SetValueFrom(ctx, types.StringType, domainNames)
 }
 
-func DomainNameElementsAs(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
-	domainNames := make([]string, len(list.Elements()))
-	diags := list.ElementsAs(ctx, &domainNames, false)
+func DomainNameElementsAs(ctx context.Context, set types.Set) ([]string, diag.Diagnostics) {
+	domainNames := make([]string, len(set.Elements()))
+	diags := set.ElementsAs(ctx, &domainNames, false)
 
 	return domainNames, diags
 }

--- a/internal/provider/models/proxy_host.go
+++ b/internal/provider/models/proxy_host.go
@@ -18,7 +18,7 @@ type ProxyHost struct {
 	OwnerUserId types.Int64  `tfsdk:"owner_user_id"`
 	Meta        types.Map    `tfsdk:"meta"`
 
-	DomainNames           types.List   `tfsdk:"domain_names"`
+	DomainNames           types.Set    `tfsdk:"domain_names"`
 	ForwardScheme         types.String `tfsdk:"forward_scheme"`
 	ForwardHost           types.String `tfsdk:"forward_host"`
 	ForwardPort           types.Int64  `tfsdk:"forward_port"`
@@ -43,7 +43,7 @@ func (_ ProxyHost) GetType() attr.Type {
 		"modified_on":             types.StringType,
 		"owner_user_id":           types.Int64Type,
 		"meta":                    types.MapType{ElemType: types.StringType},
-		"domain_names":            types.ListType{ElemType: types.StringType},
+		"domain_names":            types.SetType{ElemType: types.StringType},
 		"forward_scheme":          types.StringType,
 		"forward_host":            types.StringType,
 		"forward_port":            types.Int64Type,
@@ -95,7 +95,7 @@ func (m *ProxyHost) Write(ctx context.Context, proxyHost *nginxproxymanager.GetP
 	m.Meta, tmpDiags = MapMetaFrom(ctx, proxyHost.GetMeta())
 	diags.Append(tmpDiags...)
 
-	m.DomainNames, tmpDiags = ListDomainNamesFrom(ctx, proxyHost.GetDomainNames())
+	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, proxyHost.GetDomainNames())
 	diags.Append(tmpDiags...)
 
 	m.Locations, tmpDiags = SetProxyHostLocationsFrom(ctx, proxyHost.GetLocations())

--- a/internal/provider/models/redirection_host.go
+++ b/internal/provider/models/redirection_host.go
@@ -18,7 +18,7 @@ type RedirectionHost struct {
 	OwnerUserId types.Int64  `tfsdk:"owner_user_id"`
 	Meta        types.Map    `tfsdk:"meta"`
 
-	DomainNames       types.List   `tfsdk:"domain_names"`
+	DomainNames       types.Set    `tfsdk:"domain_names"`
 	ForwardScheme     types.String `tfsdk:"forward_scheme"`
 	ForwardDomainName types.String `tfsdk:"forward_domain_name"`
 	ForwardHttpCode   types.Int64  `tfsdk:"forward_http_code"`
@@ -40,7 +40,7 @@ func (_ RedirectionHost) GetType() attr.Type {
 		"modified_on":         types.StringType,
 		"owner_user_id":       types.Int64Type,
 		"meta":                types.MapType{ElemType: types.StringType},
-		"domain_names":        types.ListType{ElemType: types.StringType},
+		"domain_names":        types.SetType{ElemType: types.StringType},
 		"forward_scheme":      types.StringType,
 		"forward_domain_name": types.StringType,
 		"forward_http_code":   types.Int64Type,
@@ -84,7 +84,7 @@ func (m *RedirectionHost) Write(ctx context.Context, redirectionHost *nginxproxy
 	m.Meta, tmpDiags = MapMetaFrom(ctx, redirectionHost.GetMeta())
 	diags.Append(tmpDiags...)
 
-	m.DomainNames, tmpDiags = ListDomainNamesFrom(ctx, redirectionHost.GetDomainNames())
+	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, redirectionHost.GetDomainNames())
 	diags.Append(tmpDiags...)
 }
 

--- a/internal/provider/models/user.go
+++ b/internal/provider/models/user.go
@@ -21,7 +21,7 @@ type User struct {
 	Email       types.String `tfsdk:"email"`
 	Avatar      types.String `tfsdk:"avatar"`
 	IsDisabled  types.Bool   `tfsdk:"is_disabled"`
-	Roles       types.List   `tfsdk:"roles"`
+	Roles       types.Set    `tfsdk:"roles"`
 	Permissions types.Object `tfsdk:"permissions"`
 }
 
@@ -35,7 +35,7 @@ func (_ User) GetType() attr.Type {
 		"email":       types.StringType,
 		"avatar":      types.StringType,
 		"is_disabled": types.BoolType,
-		"roles":       types.ListType{ElemType: types.StringType},
+		"roles":       types.SetType{ElemType: types.StringType},
 		"permissions": types.ObjectType{AttrTypes: UserPermissions{}.GetType().AttributeTypes()},
 	})
 }
@@ -53,7 +53,7 @@ func (m *User) Write(ctx context.Context, user *nginxproxymanager.GetAccessLists
 	m.Avatar = types.StringValue(user.GetAvatar())
 	m.IsDisabled = types.BoolValue(user.GetIsDisabled())
 
-	m.Roles, tmpDiags = types.ListValueFrom(ctx, types.StringType, user.GetRoles())
+	m.Roles, tmpDiags = types.SetValueFrom(ctx, types.StringType, user.GetRoles())
 	diags.Append(tmpDiags...)
 
 	if user.HasPermissions() {

--- a/internal/provider/proxy_host_data_source.go
+++ b/internal/provider/proxy_host_data_source.go
@@ -49,7 +49,7 @@ func (d *ProxyHostDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				MarkdownDescription: "The Id of the user that owns the proxy host.",
 				Computed:            true,
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the proxy host.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/proxy_host_resource.go
+++ b/internal/provider/proxy_host_resource.go
@@ -71,7 +71,7 @@ func (r *ProxyHostResource) Schema(ctx context.Context, req resource.SchemaReque
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the proxy host.",
 				Required:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/proxy_hosts_data_source.go
+++ b/internal/provider/proxy_hosts_data_source.go
@@ -54,7 +54,7 @@ func (d *ProxyHostsDataSource) Schema(ctx context.Context, req datasource.Schema
 							MarkdownDescription: "The Id of the user that owns the proxy host.",
 							Computed:            true,
 						},
-						"domain_names": schema.ListAttribute{
+						"domain_names": schema.SetAttribute{
 							MarkdownDescription: "The domain names associated with the proxy host.",
 							Computed:            true,
 							ElementType:         types.StringType,

--- a/internal/provider/redirection_host_data_source.go
+++ b/internal/provider/redirection_host_data_source.go
@@ -49,7 +49,7 @@ func (d *RedirectionHostDataSource) Schema(ctx context.Context, req datasource.S
 				MarkdownDescription: "The Id of the user that owns the redirection host.",
 				Computed:            true,
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the redirection host.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/redirection_host_resource.go
+++ b/internal/provider/redirection_host_resource.go
@@ -70,7 +70,7 @@ func (r *RedirectionHostResource) Schema(ctx context.Context, req resource.Schem
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			"domain_names": schema.ListAttribute{
+			"domain_names": schema.SetAttribute{
 				MarkdownDescription: "The domain names associated with the redirection host.",
 				Required:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/redirection_hosts_data_source.go
+++ b/internal/provider/redirection_hosts_data_source.go
@@ -54,7 +54,7 @@ func (d *RedirectionHostsDataSource) Schema(ctx context.Context, req datasource.
 							MarkdownDescription: "The Id of the user that owns the redirection host.",
 							Computed:            true,
 						},
-						"domain_names": schema.ListAttribute{
+						"domain_names": schema.SetAttribute{
 							MarkdownDescription: "The domain names associated with the redirection host.",
 							Computed:            true,
 							ElementType:         types.StringType,

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -65,7 +65,7 @@ func (d *UserDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				MarkdownDescription: "Whether the user is disabled.",
 				Computed:            true,
 			},
-			"roles": schema.ListAttribute{
+			"roles": schema.SetAttribute{
 				MarkdownDescription: "The roles of the user.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/user_data_source_test.go
+++ b/internal/provider/user_data_source_test.go
@@ -70,7 +70,7 @@ func TestAccUserDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.nginxproxymanager_user.test",
 						tfjsonpath.New("roles"),
-						knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact("admin"),
 						}),
 					),

--- a/internal/provider/user_me_data_source.go
+++ b/internal/provider/user_me_data_source.go
@@ -65,7 +65,7 @@ func (d *UserMeDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "Whether the user is disabled.",
 				Computed:            true,
 			},
-			"roles": schema.ListAttribute{
+			"roles": schema.SetAttribute{
 				MarkdownDescription: "The roles of the user.",
 				Computed:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/user_me_data_source_test.go
+++ b/internal/provider/user_me_data_source_test.go
@@ -70,7 +70,7 @@ func TestAccUserMeDataSource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"data.nginxproxymanager_user_me.test",
 						tfjsonpath.New("roles"),
-						knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact("admin"),
 						}),
 					),

--- a/internal/provider/users_data_source.go
+++ b/internal/provider/users_data_source.go
@@ -70,7 +70,7 @@ func (d *UsersDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 							MarkdownDescription: "Whether the user is disabled.",
 							Computed:            true,
 						},
-						"roles": schema.ListAttribute{
+						"roles": schema.SetAttribute{
 							MarkdownDescription: "The roles of the user.",
 							Computed:            true,
 							ElementType:         types.StringType,

--- a/internal/provider/users_data_source_test.go
+++ b/internal/provider/users_data_source_test.go
@@ -40,7 +40,7 @@ func TestAccUsersDataSource(t *testing.T) {
 								"email":       knownvalue.StringExact("admin@example.com"),
 								"avatar":      knownvalue.StringExact(""),
 								"is_disabled": knownvalue.Bool(false),
-								"roles": knownvalue.ListExact([]knownvalue.Check{
+								"roles": knownvalue.SetExact([]knownvalue.Check{
 									knownvalue.StringExact("admin"),
 								}),
 								"permissions": knownvalue.ObjectExact(map[string]knownvalue.Check{


### PR DESCRIPTION
The List type in Terraform is ordered, while the Set type in unordered. By using a Set for `domain_names` and `roles` the order of the entries does not matter.

Closes https://github.com/Sander0542/terraform-provider-nginxproxymanager/issues/174