### PR TITLE
fix: preserve write-only fields on read instead of overwriting with null

### DIFF
--- a/internal/provider/models/certificate_letsencrypt.go
+++ b/internal/provider/models/certificate_letsencrypt.go
@@ -74,15 +74,14 @@ func (m *CertificateLetsencrypt) Write(ctx context.Context, certificate *nginxpr
 	} else {
 		m.DnsProvider = types.StringNull()
 	}
+	// DnsProviderCredentials and PropagationSeconds are write-only: NPM never
+	// returns them in read responses. Preserve the existing state value so
+	// Terraform does not see an inconsistent result after apply.
 	if meta.HasDnsProviderCredentials() {
 		m.DnsProviderCredentials = types.StringValue(meta.GetDnsProviderCredentials())
-	} else {
-		m.DnsProviderCredentials = types.StringNull()
 	}
 	if meta.HasPropagationSeconds() {
 		m.PropagationSeconds = types.Int64Value(meta.GetPropagationSeconds())
-	} else {
-		m.PropagationSeconds = types.Int64Null()
 	}
 
 	m.DomainNames, tmpDiags = SetDomainNamesFrom(ctx, certificate.GetDomainNames())


### PR DESCRIPTION
Fixes #283

## Problem

`dns_provider_credentials` and `propagation_seconds` are write-only fields. NPM intentionally never returns them in read responses. The `Write()` method was unconditionally setting them to `null` in the else branches, which causes Terraform to see an inconsistent result after apply for users who do not have `ignore_changes` on these fields.

## Fix

Remove the else branches for these two fields so the existing state value is preserved when NPM does not return them, which is always.

## Testing

Users who previously worked around this with `ignore_changes = [dns_provider_credentials, propagation_seconds]` should be able to remove that workaround after this fix.